### PR TITLE
deps!: upgrade gateway-api to support v1.5

### DIFF
--- a/backend/Berg.Api/CustomResources/GatewayApi/V1TLSRoute.cs
+++ b/backend/Berg.Api/CustomResources/GatewayApi/V1TLSRoute.cs
@@ -2,22 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace Berg.Api.CustomResources.GatewayApi;
 
-public class V1Alpha2TLSRoute : CustomResource<V1Alpha2TLSRouteSpec>
+public class V1TLSRoute : CustomResource<V1TLSRouteSpec>
 {
-    public V1Alpha2TLSRoute() : base(
+    public V1TLSRoute() : base(
         "TLSRoute",
         "tlsroutes",
         "gateway.networking.k8s.io",
-        "v1alpha2")
+        "v1")
     {
     }
 }
 
-public class V1Alpha2TLSRouteSpec : V1CommonRouteSpec
+public class V1TLSRouteSpec : V1CommonRouteSpec
 {
     [JsonPropertyName("hostnames")]
     public List<string>? Hostnames { get; set; }
 
     [JsonPropertyName("rules")]
-    public List<V1Alpha2TLSRouteRule>? Rules { get; set; }
+    public List<V1TLSRouteRule>? Rules { get; set; }
 }

--- a/backend/Berg.Api/CustomResources/GatewayApi/V1TLSRouteRule.cs
+++ b/backend/Berg.Api/CustomResources/GatewayApi/V1TLSRouteRule.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace Berg.Api.CustomResources.GatewayApi;
 
-public class V1Alpha2TLSRouteRule
+public class V1TLSRouteRule
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = default!;

--- a/backend/Berg.Api/Services/ChallengeService.cs
+++ b/backend/Berg.Api/Services/ChallengeService.cs
@@ -61,7 +61,7 @@ public class ChallengeService(
 
     private readonly GenericClient _challengeClient = CustomResource.CreateGenericClient<V1Challenge>(kubernetes, false);
     private readonly GenericClient _httpRouteClient = CustomResource.CreateGenericClient<V1HTTPRoute>(kubernetes, false);
-    private readonly GenericClient _tlsRouteClient = CustomResource.CreateGenericClient<V1Alpha2TLSRoute>(kubernetes, false);
+    private readonly GenericClient _tlsRouteClient = CustomResource.CreateGenericClient<V1TLSRoute>(kubernetes, false);
     private readonly GenericClient _ciliumNetworkPolicyClient = CustomResource.CreateGenericClient<V2CiliumNetworkPolicy>(kubernetes, false);
 
     public async Task<IEnumerable<V1Challenge>> GetChallenges(CancellationToken cancellationToken)
@@ -219,7 +219,7 @@ public class ChallengeService(
         var httpRouteList = await _httpRouteClient
             .ListNamespacedAsync<CustomResourceList<V1HTTPRoute>>(ns.Name(), cancel: cancellationToken);
         var tlsRouteList = await _tlsRouteClient
-            .ListNamespacedAsync<CustomResourceList<V1Alpha2TLSRoute>>(ns.Name(), cancel: cancellationToken);
+            .ListNamespacedAsync<CustomResourceList<V1TLSRoute>>(ns.Name(), cancel: cancellationToken);
 
         var services = new List<Service>();
         foreach (var container in challenge.Spec.Containers ?? [])
@@ -711,7 +711,7 @@ public class ChallengeService(
             foreach (var tlsRoutePort in tlsRoutePorts)
             {
                 var serviceGuid = Guid.NewGuid();
-                var tlsRoute = new V1Alpha2TLSRoute()
+                var tlsRoute = new V1TLSRoute()
                 {
                     Metadata = new V1ObjectMeta
                     {
@@ -724,7 +724,7 @@ public class ChallengeService(
                             { HostnameLabel, $"{serviceGuid}" }
                         }
                     },
-                    Spec = new V1Alpha2TLSRouteSpec
+                    Spec = new V1TLSRouteSpec
                     {
                         Hostnames =
                         [

--- a/docs/production.md
+++ b/docs/production.md
@@ -70,8 +70,8 @@ EOF
 ## Traefik
 
 ```sh
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/experimental-install.yaml
-cat <<EOF | helm install --wait traefik traefik/traefik --version v35.4.0 -n traefik --create-namespace -f -
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+cat <<EOF | helm install --wait traefik traefik/traefik --version 40.2.0 -n traefik --create-namespace -f -
 globalArguments:
   - "--global.checknewversion=false"
   - "--global.sendanonymoususage=false"
@@ -119,7 +119,6 @@ providers:
       enabled: true
   kubernetesGateway:
     enabled: true
-    experimentalChannel: true
 service:
   type: LoadBalancer
 ports:

--- a/setup-local.sh
+++ b/setup-local.sh
@@ -90,7 +90,7 @@ hubble:
 EOF
 
 echo "Installing traefik"
-cat <<EOF | helm --kube-context kind-berg-dev-cluster install --wait traefik traefik/traefik --version 35.4.0 -n traefik --create-namespace -f -
+cat <<EOF | helm --kube-context kind-berg-dev-cluster install --wait traefik traefik/traefik --version 40.2.0 -n traefik --create-namespace -f -
 globalArguments:
   - "--global.checknewversion=false"
   - "--global.sendanonymoususage=false"
@@ -138,7 +138,6 @@ providers:
       enabled: true
   kubernetesGateway:
     enabled: true
-    experimentalChannel: true
 service:
   type: NodePort
 ports:
@@ -172,7 +171,7 @@ tlsOptions:
 EOF
 
 echo "Installing Gateway API CRDs"
-kubectl --context kind-berg-dev-cluster apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/experimental-install.yaml
+kubectl --context kind-berg-dev-cluster apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 echo "Installing cert-manager"
 helm --kube-context kind-berg-dev-cluster install --wait \


### PR DESCRIPTION
(breaking change)

- [Gateway API Changelog](https://github.com/kubernetes-sigs/gateway-api/blob/main/CHANGELOG/1.5-CHANGELOG.md)
- Graduate TLSRoute from v1 to v1alpha2
  - TLSRoute is now available in Standard, no need for experimental